### PR TITLE
Add config option to disable auto line wrap

### DIFF
--- a/start.py
+++ b/start.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QApplication, QWidget, QHBoxLayout, QScrollBar
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtGui import QFont
 
+import termqt
 from termqt import Terminal
 
 if __name__ == "__main__":
@@ -36,30 +37,39 @@ if __name__ == "__main__":
 
     window.show()
 
+    auto_wrap_enabled = True
+
     platform = platform.system()
 
     if platform in ["Linux", "Darwin"]:
-        command = "/bin/bash"
+        bin = "/bin/bash"
 
         from termqt import TerminalPOSIXExecIO
         terminal_io = TerminalPOSIXExecIO(
-            terminal.row_len,
-            terminal.col_len,
-            command,
-            logger=logger
-        )
+                terminal.row_len,
+                terminal.col_len,
+                bin,
+                logger=logger
+                )
     elif platform == "Windows":
-        command = "cmd"
+        bin = "cmd"
+
         from termqt import TerminalWinptyIO
         terminal_io = TerminalWinptyIO(
-            terminal.row_len,
-            terminal.col_len,
-            command,
-            logger=logger
-        )
+                terminal.row_len,
+                terminal.col_len,
+                bin,
+                logger=logger
+                )
+
+        # it turned out that cmd prefers to handle resize by itself
+        # see https://github.com/TerryGeng/termqt/issues/7
+        auto_wrap_enabled = False
     else:
         logger.error(f"Not supported platform: {platform}")
         sys.exit(-1)
+
+    terminal.enable_auto_wrap(auto_wrap_enabled)
 
     terminal_io.stdout_callback = terminal.stdout
     terminal.stdin_callback = terminal_io.write

--- a/termqt/terminal_buffer.py
+++ b/termqt/terminal_buffer.py
@@ -557,7 +557,12 @@ class EscapeProcessor:
 
 
 class TerminalBuffer:
-    def __init__(self, row_len=0, col_len=0, logger=None):
+    def __init__(self,
+                 row_len,
+                 col_len,
+                 *,
+                 logger=None,
+                 ):
         self.logger = logger
 
         # initialize a buffer to store all characters to display

--- a/termqt/terminal_widget.py
+++ b/termqt/terminal_widget.py
@@ -48,7 +48,8 @@ class Terminal(TerminalBuffer, QWidget):
                  padding=4,
                  font_size=12,
                  line_height_factor=1.2,
-                 font=None
+                 font=None,
+                 **kwargs
                  ):
 
         QWidget.__init__(self)
@@ -58,7 +59,7 @@ class Terminal(TerminalBuffer, QWidget):
         self.logger = logger if logger else logging.getLogger()
         self.logger.info("Initializing Terminal...")
 
-        TerminalBuffer.__init__(self, 0, 0, logger=logger)
+        TerminalBuffer.__init__(self, 0, 0, logger=logger, **kwargs)
 
         # we paint everything to the pixmap first then paint this pixmap
         # on paint event. This allows us to partially update the canvas.


### PR DESCRIPTION
As discussed in #7, it seems that `cmd` doesn't want the terminal to do auto line wrap for it. It has some weird internal logic that handles line wrap in quite an imperfect way.

Now it should have solved #7. Indeed, resizing under Windows still works in a somehow jittery way but that's already `cmd`'s problem instead of my problem...

@matkuki Would you please, again, have a look at this?