### PR TITLE
setup.py: Add pywinpty as a dep when Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description="A terminal emulator widget built on PyQt5.",
     keywords="terminal emulator pyqt",
     url="https://github.com/TerryGeng/termqt",
-    install_requires=("PyQt5", "PyQt5-sip", "Qt.py"),
+    install_requires=("PyQt5", "PyQt5-sip", "Qt.py", "pywinpty; platform_system=='Windows'"),
     classifiers=[
         "Environment :: X11 Applications :: Qt",
         "Operating System :: POSIX",


### PR DESCRIPTION
When installing termqt in a virtual environment with Qt5 on a Windows 10 platform, winpty was not available

After some initial research, it seems that andfoy's [PyWinpty](https://pypi.org/project/pywinpty/) may represent a successor to [winpty](https://github.com/rprichard/winpty). 

PyWinpty is built with Rust.  There's a prebuilt pywinpty distribution available at PyPI

With PyWinpty installed, termqt's `start.py` runs as hoped, in this platform environment.

So, this changeset adds pywinpty as a runtime dependency in setup.py, when installing termqt on Windows