### PR TITLE
feat: Qt.py changed to qtpy; added support for PyQt6 and PySide6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ people, it can run IPython and perhaps more complicated applications.
 ## Dependencies
 
 - Python 3.5+ (to get PyQt5 running),
-- PyQt5 / PySide2.
+- PyQt5 /PyQt6 / PySide2 / PySide6.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A terminal emulator widget implemented in Python/Qt."
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "Qt.py >= 1.3.0",
+    "qtpy",
     "pywinpty >= 2.0.1; platform_system=='Windows'"
 ]
 classifiers = [

--- a/start.py
+++ b/start.py
@@ -1,9 +1,9 @@
 import sys
 import logging
 import platform
-from PyQt5.QtWidgets import QApplication, QWidget, QHBoxLayout, QScrollBar
-from PyQt5.QtCore import Qt, QCoreApplication
-from PyQt5.QtGui import QFont
+from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout, QScrollBar
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QFont
 
 import termqt
 from termqt import Terminal
@@ -19,7 +19,6 @@ if __name__ == "__main__":
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
-    QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     app = QApplication([])
     window = QWidget()
     window.setWindowTitle("termqt on {}".format(platform.system()))

--- a/start.py
+++ b/start.py
@@ -2,7 +2,8 @@ import sys
 import logging
 import platform
 from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout, QScrollBar
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QCoreApplication
+from qtpy import QT_VERSION
 from qtpy.QtGui import QFont
 
 import termqt
@@ -19,6 +20,8 @@ if __name__ == "__main__":
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
+    if QT_VERSION.startswith("5"):
+        QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     app = QApplication([])
     window = QWidget()
     window.setWindowTitle("termqt on {}".format(platform.system()))

--- a/termqt/colors.py
+++ b/termqt/colors.py
@@ -1,4 +1,4 @@
-from Qt.QtGui import QColor
+from qtpy.QtGui import QColor
 
 # This file stores all xterm-256 colors.
 # See https://jonasjacek.github.io/colors/

--- a/termqt/terminal_buffer.py
+++ b/termqt/terminal_buffer.py
@@ -4,8 +4,9 @@ from enum import Enum
 from functools import partial
 from collections import deque
 
-from Qt.QtGui import QColor
-from Qt.QtCore import Qt, QMutex
+from qtpy import QT_VERSION
+from qtpy.QtGui import QColor
+from qtpy.QtCore import Qt, QRecursiveMutex, QMutex
 
 from .colors import colors8, colors16, colors256
 
@@ -652,7 +653,10 @@ class TerminalBuffer:
         # initialize a buffer to store all characters to display
         # define in _resize()_ as a deque
         self._buffer = None
-        self._buffer_lock = QMutex(QMutex.Recursive)
+        if QT_VERSION.startswith('6'):
+            self._buffer_lock =QRecursiveMutex()
+        else:
+            self._buffer_lock = QMutex(QMutex.Recursive)
 
         self.auto_wrap_enabled = auto_wrap_enabled
         # used to store the line number of lines that are wrapped automatically

--- a/termqt/terminal_widget.py
+++ b/termqt/terminal_widget.py
@@ -214,36 +214,26 @@ class Terminal(TerminalBuffer, QWidget):
         self.setPalette(pal)
 
     def set_font(self, font: QFont = None):
-        if QT_VERSION.startswith("6"):
-            self._set_font_qt6(font)
-        else:
-            self._set_font_qt5(font)
-
-    def _set_font_qt5(self, font: QFont):
-        qfd = QFontDatabase()
-        font, info = self._select_font(qfd, font)
+        is_qt6 = QT_VERSION.startswith("6")
+        qfd = QFontDatabase if is_qt6 else QFontDatabase()
+        fix_font_flag = QFontDatabase.SystemFont.FixedFont if is_qt6 else QFontDatabase.FixedFont
+        font, info = self._select_font(qfd, font, fix_font_flag)
         self._apply_font_settings(font, info)
 
-    def _set_font_qt6(self, font: QFont):
-        font, info = self._select_font(None, font)
-        self._apply_font_settings(font, info)
-
-    def _select_font(self, qfd: QFontDatabase, font: QFont):
+    def _select_font(self, qfd, font: QFont, fix_font_flag):
         if font:
             info = QFontInfo(font)
             if info.styleHint() != QFont.Monospace:
-                self.logger.warning("font: Please use monospaced font! Unsupported font {info.family()}.")
-                font = qfd.systemFont(QFontDatabase.FixedFont) if qfd else QFontDatabase.systemFont(
-                    QFontDatabase.SystemFont.FixedFont)
-        elif qfd and "Menlo" in qfd.families():
+                self.logger.warning(f"font: Please use a monospaced font! Unsupported font {info.family()}.")
+                font = qfd.systemFont(fix_font_flag) if qfd else QFontDatabase.systemFont(fix_font_flag)
+        elif not qfd or "Menlo" in qfd.families():
             font = QFont("Menlo")
             info = QFontInfo(font)
-        elif qfd and "Consolas" in qfd.families():
+        elif not qfd or "Consolas" in qfd.families():
             font = QFont("Consolas")
             info = QFontInfo(font)
         else:
-            font = qfd.systemFont(QFontDatabase.FixedFont) if qfd else QFontDatabase.systemFont(
-                QFontDatabase.SystemFont.FixedFont)
+            font = qfd.systemFont(fix_font_flag) if qfd else QFontDatabase.systemFont(fix_font_flag)
             info = QFontInfo(font)
         return font, info
 


### PR DESCRIPTION
Changed the `Qt` abstraction layer from `Qt.py` to `qtpy`. This allows the use of `PyQt5`, `PyQt6`, `PySide2`, and `PySide6`.

I also adapted parts of the code that differ between `qt5` and `qt6` (e.g., `QMutex`, `QFontDatabase`).